### PR TITLE
🐛 Fix miscalculated `max_nde` value

### DIFF
--- a/LOC.py
+++ b/LOC.py
@@ -818,12 +818,8 @@ def WriteSpectra(INI, u, l):
     ##NTRUE       =  zeros(NRA*INI['channels'], float32)
     STEP        =  INI['grid'] / INI['angle']      # pixel size in GL units
     emissivity  =  (PLANCK/(4.0*pi))*freq*Aul*int2temp    
-    direction   =  cl.cltypes.make_float2() 
-    direction['x'], direction['y'] = INI['direction']
-    offsets                     =  cl.cltypes.make_float2()
-    offsets['x'], offsets['y']  =  0.5*(NRA-1.0),   0.5*(NDE-1.0)
-    if (isfinite(sum(INI['map_offsets'][0]))):
-        offsets['x'], offsets['y']  = INI['map_offsets']  # map centre in pixel units
+    direction   =  cl.cltypes.make_float2()
+    offsets                     =  cl.cltypes.make_float2()  # map centre in pixel units
 
     if (HFS): # note -- GAU is for CHANNELS channels = maximum over all bands!!
         for i in range(ncmp):
@@ -926,6 +922,7 @@ def WriteSpectra(INI, u, l):
         tau.tofile(fptau)      # file containing peak tau for each spectrum
     fp.close()
     fptau.close()
+    print(">>>>>>>", NRA, NDE)
     print("  SPECTRUM %3d  = %2d -> %2d,  <tau_peak> = %.3e" % (tran, u, l, ave_tau/(NRA*NDE)))
     
     

--- a/LOC_aux.py
+++ b/LOC_aux.py
@@ -563,7 +563,7 @@ def ReadIni(filename):
     max_nra, max_nde = 0, 0
     for i in range(len(INI['mapview'])):
         max_nra = max(max_nra, INI['mapview'][i][2])
-        max_nra = max(max_nra, INI['mapview'][i][2])
+        max_nde = max(max_nde, INI['mapview'][i][3])
     INI['points'] = [ max_nra, max_nde]
     # INI['direction'] is no longer needed
     INI['direction'] = []


### PR DESCRIPTION
> **Note**
>
> This PR require the approval of https://github.com/mjuvela/LOC/pull/3

Hi,
I found 2 lines that are identical but are not supposed to. It result in having `max_nde` always set to 0 and then havin `INI['points'][1]` always to 0, which induce a division by 0 at `LOC.py:926`