### PR TITLE
fix prefix in WriteSpectraOL

### DIFF
--- a/LOC_OT.py
+++ b/LOC_OT.py
@@ -3166,10 +3166,10 @@ def WriteSpectraOL(INI, OLBAND, iband):
         if (fwhm>0.0):
             fp[0].data = ConvolveCube(fp[0].data, fwhm, INI['GPU'], INI['platforms'])
             fp[0].header['BEAM'] = fwhm*INI['grid']/3600.0            
-        fp.writeto('OL_%s_%s_%02d-%02d%s.fits'        % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
+        fp.writeto('%s_OL_%s_%02d-%02d%s.fits'        % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
         if (TAUSAVE):
             #  TAU not convolved !
-            fptau.writeto('%s_%s_%02d-%02d_tau%s.fits' % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
+            fptau.writeto('%s_OL_%s_%02d-%02d_tau%s.fits' % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
             del fptau
         print("  SPECTRUM %3d  = %2d -> %2d,  <tau_peak> = %.3e" % (tran0, u0, l0, ave_tau/(NRA*NDE)))
 

--- a/LOC_OT.py
+++ b/LOC_OT.py
@@ -342,7 +342,7 @@ if (OCTREE>0):
 else:
     print("USING  program.Update")
     kernel_sim                           =  program.Update
-    if (WITH_OVERLAP):  kernel_sim_ol    =  program.UpdateOL
+    if (WITH_OVERLAP):  kernel_sim    =  program.UpdateOL
     if (PLWEIGHT):      kernel_paths     =  program.Paths
 
 kernel_solve         =  program.SolveCL
@@ -3166,10 +3166,10 @@ def WriteSpectraOL(INI, OLBAND, iband):
         if (fwhm>0.0):
             fp[0].data = ConvolveCube(fp[0].data, fwhm, INI['GPU'], INI['platforms'])
             fp[0].header['BEAM'] = fwhm*INI['grid']/3600.0            
-        fp.writeto('%s_OL_%s_%02d-%02d%s.fits'        % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
+        fp.writeto('%s_%s_%02d-%02d%s_OL.fits'        % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
         if (TAUSAVE):
             #  TAU not convolved !
-            fptau.writeto('%s_OL_%s_%02d-%02d_tau%s.fits' % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
+            fptau.writeto('%s_%s_%02d-%02d_tau%s_OL.fits' % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)
             del fptau
         print("  SPECTRUM %3d  = %2d -> %2d,  <tau_peak> = %.3e" % (tran0, u0, l0, ave_tau/(NRA*NDE)))
 


### PR DESCRIPTION
Hi, I am using your code and came to this problem:
```
*************************************                                                                     
***** write overlapping spectra *****                                                                     
*************************************                                                                     
Traceback (most recent call last):                                                                                                                                                                                  
  File "/datastore/edombek/rpycorefit/corefit/loc/LOC_OT.py", line 3780, in <module>
    WriteSpectraOL(INI, OLBAND, iband)                                                                    
  File "/datastore/edombek/rpycorefit/corefit/loc/LOC_OT.py", line 3169, in WriteSpectraOL                
    fp.writeto('OL_%s_%s_%02d-%02d%s.fits'        % (INI['prefix'], MOL.NAME, u0, l0, ['', '.%03d' % iview][NVIEW>1]), overwrite=True)                                                                              
  File "/usr/lib/python3/dist-packages/astropy/io/fits/hdu/hdulist.py", line 1020, in writeto                                                                                                                       
    fileobj = _File(fileobj, mode=mode, overwrite=overwrite)                                                                                                                                                        
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                        
  File "/usr/lib/python3/dist-packages/astropy/io/fits/file.py", line 218, in __init__                    
    self._open_filename(fileobj, mode, overwrite)                                                         
  File "/usr/lib/python3/dist-packages/astropy/io/fits/file.py", line 641, in _open_filename
    self._file = open(self.name, IO_FITS_MODES[mode])                                                                                                                                                               
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                     
FileNotFoundError: [Errno 2] No such file or directory: 'OL_/tmp/loc-6q3dxwh5/121:LOC:H13CN:1_0_HCN_01-00.fits'
```
Therefore, I propose the following solution.